### PR TITLE
Exclude admins when looking for abandoned orders

### DIFF
--- a/src/services/Carts.php
+++ b/src/services/Carts.php
@@ -115,9 +115,13 @@ class Carts extends Component
     
     // Get all abandoned commerce orders that have been inactive for more than 1hr
     // But no further back than 12 hours
+    // Exclude admins by email address
     // Note: Commerce::purgeInactiveCartsDuration() may come into play here.
     public function getAbandonedOrders($start = '1', $end = '12')
     {        
+
+        $adminEmails = array_map(function($admin){ return $admin->email; },User::find()->admin()->all());
+        
         // Find orders that fit the criteria
         $carts = Order::find();
         $carts->where('commerce_orders.dateUpdated <= DATE_ADD(NOW(), INTERVAL - '.$start.' HOUR)');
@@ -125,6 +129,7 @@ class Carts extends Component
         $carts->andWhere('totalPrice > 0');
         $carts->andWhere('isCompleted = 0');
         $carts->andWhere('email != ""');
+        $carts->andWhere('email NOT IN ("'.join('","',$adminEmails).'")');
         $carts->orderBy('commerce_orders.dateUpdated desc');
         $carts->all();
         return $carts;


### PR DESCRIPTION
Myles,

I'm not sure how you feel about this, but during testing our own abandoned carts have been making it hard to see the wood for the trees.

This could maybe be a setting in the control panel, but I thought I'd get your initial thoughts on this so far.