### PR TITLE
The settings options should not been shown in the control panel when devmode is off

### DIFF
--- a/src/AbandonedCart.php
+++ b/src/AbandonedCart.php
@@ -103,15 +103,22 @@ class AbandonedCart extends Plugin
     {
         $navItem = parent::getCpNavItem();
         $navItem['label'] = $this->getPluginName();
+        
+        if ( !Craft::$app->getConfig()->general->devMode ) {
+            
+            $navItem['subnav']['dashboard'] = [
+                'label' => Craft::t('app', 'Dashboard'),
+                'url' => 'abandoned-cart/dashboard'
+            ];
 
-        $navItem['subnav']['dashboard'] = [
-            'label' => Craft::t('app', 'Dashboard'),
-            'url' => 'abandoned-cart/dashboard'
-        ];
-        $navItem['subnav']['settings'] = [
-            'label' => Craft::t('app', 'Settings'),
-            'url' => 'abandoned-cart/settings'
-        ];
+            $navItem['subnav']['settings'] = [
+                'label' => Craft::t('app', 'Settings'),
+                'url' => 'abandoned-cart/settings'
+            ];
+            return $navItem;
+        }
+
+        $navItem['url'] = 'abandoned-cart/dashboard';
 
         return $navItem;
     }

--- a/src/services/Carts.php
+++ b/src/services/Carts.php
@@ -115,9 +115,13 @@ class Carts extends Component
     
     // Get all abandoned commerce orders that have been inactive for more than 1hr
     // But no further back than 12 hours
+    // Exclude admins by email address
     // Note: Commerce::purgeInactiveCartsDuration() may come into play here.
     public function getAbandonedOrders($start = '1', $end = '12')
     {        
+
+        $adminEmails = array_map(function($admin){ return $admin->email; },User::find()->admin()->all());
+        
         // Find orders that fit the criteria
         $carts = Order::find();
         $carts->where('commerce_orders.dateUpdated <= DATE_ADD(NOW(), INTERVAL - '.$start.' HOUR)');
@@ -125,6 +129,7 @@ class Carts extends Component
         $carts->andWhere('totalPrice > 0');
         $carts->andWhere('isCompleted = 0');
         $carts->andWhere('email != ""');
+        $carts->andWhere('email NOT IN ("'.join('","',$adminEmails).'")');
         $carts->orderBy('commerce_orders.dateUpdated desc');
         $carts->all();
         return $carts;


### PR DESCRIPTION
This brings the plug in in-line with the standard CP behaviour. 