### PR TITLE
Added multi-site support

### DIFF
--- a/src/services/Carts.php
+++ b/src/services/Carts.php
@@ -146,7 +146,7 @@ class Carts extends Component
 
         $carts = Order::find();
         $carts->where(['<=', 'commerce_orders.dateUpdated', $dateUpdatedStart->format('Y-m-d H:i:s')]);
-        $carts->andWhere(['>=', 'commerce_orders.dateUpdated', $dateUpdatedEnd->format('Y-m-d H:i:s')]);        
+        $carts->andWhere(['>=', 'commerce_orders.dateUpdated', $dateUpdatedEnd->format('Y-m-d H:i:s')]);
         $carts->andWhere('totalPrice > 0');
         $carts->andWhere('isCompleted = 0');
         $carts->andWhere('email != ""');
@@ -285,6 +285,9 @@ class Carts extends Component
             return false;
         }
 
+        // use order language
+        Craft::$app->language = $order->orderLanguage;
+
         $checkoutLink = 'abandoned-cart-restore?number=' . $order->number;
 
         $discount = Craft::parseEnv(AbandonedCart::$plugin->getSettings()->discountCode);
@@ -299,9 +302,11 @@ class Carts extends Component
         $renderVariables = [
             'order' => $order,
             'discount' => $discountCode,
+            'currentSite' => $order->orderSite,
             'checkoutLink' => $checkoutLink
         ];
 
+        $subject = $view->renderString($subject, $renderVariables);
         $templatePath = $view->renderString($templatePath, $renderVariables);
 
         // validate that the email template exists


### PR DESCRIPTION
Hello guys,
I also need multi-site support as requested in this issue: https://github.com/mediabeastnz/craft-commerce-abandoned-cart/issues/51

I have drafted a PR that sets Craft's language to the one used in order so that translations can be used.

The "1st Reminder Email Subject" and "2nd Reminder Subject" fields in **Settings** section now support Twig (as managed in Craft Commerce).

It is therefore possible to translate the subject of the email using the syntax:
`{{ 'You have left some items in your cart'|t }}`

Let me know what you think.