### PR TITLE
Check for non existent purchasable on 1.x branch

### DIFF
--- a/src/controllers/BaseController.php
+++ b/src/controllers/BaseController.php
@@ -268,9 +268,9 @@ class BaseController extends Controller
                         if ($order->lineItems) {
                             foreach ($order->lineItems as $item) {
                                 $results[$cart->id]['order']['items'][$item->purchasableId] = [
-                                    "title" => $item->purchasable->title,
+                                    "title" => isset($item->purchasable->title) ? $item->purchasable->title : "-",
                                     "sku" => $item->sku,
-                                    "purchasableId" => $item->purchasableId,
+                                    "purchasableId" => isset($item->purchasableId) ? $item->purchasableId : "-",
                                     "total" => $item->total,
                                     "qty" => $item->qty
                                 ];


### PR DESCRIPTION
Looking at this issue: https://github.com/mediabeastnz/craft-commerce-abandoned-cart/issues/68

You pushed up this simple fix but only into the 2.x version which requires Craft 4. I'm creating this PR to get it into the 1.x version for people still on Craft 3.

Due to 1.x and 2.x using the same branch I'm not sure how to actually structure this PR as it doesn't let me target the tag 1.6.5 which is where I made my code changes. Maybe converting 1.6.5 tag into a branch called 1.x then make new tags from that? Let me know how to get the PR fixed, and I'll make whatever changes are needed.

